### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -4,44 +4,16 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release-'
     tags: '*'
   pull_request:
 
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
 jobs:
-  build:
+  runic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
         with:
-          version: 1
-      - name: Install JuliaFormatter
-        run: |
-          using Pkg
-          name = "JuliaFormatter"
-          uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-          Pkg.add(; name, uuid)
-        shell: julia --color=yes {0}
-      - name: Format Julia code
-        run: |
-          using JuliaFormatter
-          format("."; verbose = true)
-        shell: julia --color=yes {0}
-      - name: Format check
-        run: |
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end
-        shell: julia --color=yes {0}
+          version: '1'

--- a/lib/burgers.jl
+++ b/lib/burgers.jl
@@ -21,21 +21,27 @@ function inviscid_burgers_monotonic()
 
     eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ x,
+    bcs = [
+        u(0, x) ~ x,
         u(t, x_min) ~ analytic_u(t, x_min),
-        u(t, x_max) ~ analytic_u(t, x_max)]
+        u(t, x_max) ~ analytic_u(t, x_max),
+    ]
 
-    domains = [t ∈ Interval(t_min, t_max),
-        x ∈ Interval(x_min, x_max)]
+    domains = [
+        t ∈ Interval(t_min, t_max),
+        x ∈ Interval(x_min, x_max),
+    ]
 
     dx = 0.05
 
     tags = ["1D", "Monotonic", "Inviscid", "Burgers", "Advection", "Dirichlet"]
 
-    @named inviscid_burgers_monotonic = PDESystem(eq, bcs, domains, [t, x], [u(t, x)];
-        analytic = analytic, metadata = tags)
+    @named inviscid_burgers_monotonic = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)];
+        analytic = analytic, metadata = tags
+    )
 
-    inviscid_burgers_monotonic
+    return inviscid_burgers_monotonic
 end
 
 """
@@ -63,33 +69,58 @@ function burgers_2d()
 
     u_exact(x, y, t) = 3 / 4 - 1 / (4 * (1 + exp(R * (-t - 4x + 4y) / 32)))
     v_exact(x, y, t) = 3 / 4 + 1 / (4 * (1 + exp(R * (-t - 4x + 4y) / 32)))
-    analytic = [u(x, y, t) ~ u_exact(x, y, t),
-        v(x, y, t) ~ v_exact(x, y, t)]
+    analytic = [
+        u(x, y, t) ~ u_exact(x, y, t),
+        v(x, y, t) ~ v_exact(x, y, t),
+    ]
 
     eq = [
         Dt(u(x, y, t)) + u(x, y, t) * Dx(u(x, y, t)) + v(x, y, t) * Dy(u(x, y, t)) ~
-        (1 / R) *
-        (Dxx(u(x,
-            y,
-            t)) +
-         Dyy(u(x,
-            y,
-            t))),
+            (1 / R) *
+            (
+            Dxx(
+                u(
+                    x,
+                    y,
+                    t
+                )
+            ) +
+                Dyy(
+                u(
+                    x,
+                    y,
+                    t
+                )
+            )
+        ),
         Dt(v(x, y, t)) + u(x, y, t) * Dx(v(x, y, t)) + v(x, y, t) * Dy(v(x, y, t)) ~
-        (1 / R) *
-        (Dxx(v(x,
-            y,
-            t)) +
-         Dyy(v(x,
-            y,
-            t)))
+            (1 / R) *
+            (
+            Dxx(
+                v(
+                    x,
+                    y,
+                    t
+                )
+            ) +
+                Dyy(
+                v(
+                    x,
+                    y,
+                    t
+                )
+            )
+        ),
     ]
 
-    domains = [x ∈ Interval(x_min, x_max),
+    domains = [
+        x ∈ Interval(x_min, x_max),
         y ∈ Interval(y_min, y_max),
-        t ∈ Interval(t_min, t_max)]
+        t ∈ Interval(t_min, t_max),
+    ]
 
-    bcs = [u(x, y, 0) ~ u_exact(x, y, 0),
+    bcs = [
+        u(x, y, 0) ~ u_exact(x, y, 0),
         u(0, y, t) ~ u_exact(0, y, t),
         u(x, 0, t) ~ u_exact(x, 0, t),
         u(1, y, t) ~ u_exact(1, y, t),
@@ -97,14 +128,17 @@ function burgers_2d()
         v(0, y, t) ~ v_exact(0, y, t),
         v(x, 0, t) ~ v_exact(x, 0, t),
         v(1, y, t) ~ v_exact(1, y, t),
-        v(x, 1, t) ~ v_exact(x, 1, t)]
+        v(x, 1, t) ~ v_exact(x, 1, t),
+    ]
 
     tags = ["2D", "Non-Monotonic", "Viscous", "Burgers", "Advection", "Dirichlet"]
 
-    @named burgers_2d = PDESystem(eq, bcs, domains, [t, x, y], [u(x, y, t), v(x, y, t)],
-        analytic = analytic, metadata = tags)
+    @named burgers_2d = PDESystem(
+        eq, bcs, domains, [t, x, y], [u(x, y, t), v(x, y, t)],
+        analytic = analytic, metadata = tags
+    )
 
-    burgers_2d
+    return burgers_2d
 end
 
 all_systems = vcat(all_systems, [inviscid_burgers_monotonic(), burgers_2d()])

--- a/lib/general_linear_system.jl
+++ b/lib/general_linear_system.jl
@@ -9,13 +9,17 @@ function general_system(α, β, γ, δ, name = :sys)
     Dxxxx = Differential(x)^4
 
     eq = Dt(u(t, x)) + α * Dx(u(t, x)) ~
-         β * Dxx(u(t, x)) + γ * Dxxx(u(t, x)) -
-         δ * Dxxxx(u(t, x))
-    domain = [x ∈ Interval(0.0, 2π),
-        t ∈ Interval(0.0, 3.0)]
+        β * Dxx(u(t, x)) + γ * Dxxx(u(t, x)) -
+        δ * Dxxxx(u(t, x))
+    domain = [
+        x ∈ Interval(0.0, 2π),
+        t ∈ Interval(0.0, 3.0),
+    ]
 
-    ic_bc = [u(0.0, x) ~ cos(x)^2,
-        u(t, 0.0) ~ u(t, 2π)]
+    ic_bc = [
+        u(0.0, x) ~ cos(x)^2,
+        u(t, 0.0) ~ u(t, 2π),
+    ]
 
     analytic = [u(t, x) ~ 0.5 * (exp(-t * 4(β + 4δ)) * cos(t * (-8γ - 2α) + 2x) + 1)]
 
@@ -24,43 +28,60 @@ end
 
 function build_with_tags(sys, tags)
     eq, ic_bc, domain, indvars, depvars, analytic, name = sys
-    sys = PDESystem(eq, ic_bc, domain, indvars, depvars, name = name,
-        analytic = analytic, metadata = tags)
+    sys = PDESystem(
+        eq, ic_bc, domain, indvars, depvars, name = name,
+        analytic = analytic, metadata = tags
+    )
     return sys
 end
 
-adv = build_with_tags(general_system(1.0, 0.0, 0.0, 0.0, :adv),
-    ["1D", "Advection", "Linear", "Periodic"])
-diff = build_with_tags(general_system(0.0, 1.0, 0.0, 0.0, :diff),
-    ["1D", "Diffusion", "Linear", "Periodic"])
-adv3 = build_with_tags(general_system(0.0, 0.0, 1.0, 0.0, :adv3),
-    ["1D", "3rd Order", "Linear", "Periodic"])
-diff4 = build_with_tags(general_system(0.0, 0.0, 0.0, 1.0, :diff4),
-    ["1D", "4th Order", "Linear", "Periodic"])
+adv = build_with_tags(
+    general_system(1.0, 0.0, 0.0, 0.0, :adv),
+    ["1D", "Advection", "Linear", "Periodic"]
+)
+diff = build_with_tags(
+    general_system(0.0, 1.0, 0.0, 0.0, :diff),
+    ["1D", "Diffusion", "Linear", "Periodic"]
+)
+adv3 = build_with_tags(
+    general_system(0.0, 0.0, 1.0, 0.0, :adv3),
+    ["1D", "3rd Order", "Linear", "Periodic"]
+)
+diff4 = build_with_tags(
+    general_system(0.0, 0.0, 0.0, 1.0, :diff4),
+    ["1D", "4th Order", "Linear", "Periodic"]
+)
 
-advdiff = build_with_tags(general_system(1.0, 1.0, 0.0, 0.0, :advdiff),
-    ["1D", "Advection", "Diffusion", "Linear", "Periodic"])
+advdiff = build_with_tags(
+    general_system(1.0, 1.0, 0.0, 0.0, :advdiff),
+    ["1D", "Advection", "Diffusion", "Linear", "Periodic"]
+)
 
-advdiff3 = build_with_tags(general_system(1.0, 1.0, 1.0, 0.0, :advdiff3),
+advdiff3 = build_with_tags(
+    general_system(1.0, 1.0, 1.0, 0.0, :advdiff3),
     [
         "1D",
         "Advection",
         "Diffusion",
         "3rd Order",
         "Linear",
-        "Periodic"
-    ])
-advdiffno3 = build_with_tags(general_system(1.0, 1.0, 0.0, 1.0, :advdiffno3),
+        "Periodic",
+    ]
+)
+advdiffno3 = build_with_tags(
+    general_system(1.0, 1.0, 0.0, 1.0, :advdiffno3),
     [
         "1D",
         "Advection",
         "Diffusion",
         "4th Order",
         "Linear",
-        "Periodic"
-    ])
+        "Periodic",
+    ]
+)
 
-gen1 = build_with_tags(general_system(rand(4)..., :gen1),
+gen1 = build_with_tags(
+    general_system(rand(4)..., :gen1),
     [
         "1D",
         "Advection",
@@ -68,9 +89,11 @@ gen1 = build_with_tags(general_system(rand(4)..., :gen1),
         "3rd Order",
         "4th Order",
         "Linear",
-        "Periodic"
-    ])
-gen2 = build_with_tags(general_system(rand(4)..., :gen2),
+        "Periodic",
+    ]
+)
+gen2 = build_with_tags(
+    general_system(rand(4)..., :gen2),
     [
         "1D",
         "Advection",
@@ -78,9 +101,11 @@ gen2 = build_with_tags(general_system(rand(4)..., :gen2),
         "3rd Order",
         "4th Order",
         "Linear",
-        "Periodic"
-    ])
-gen3 = build_with_tags(general_system(rand(4)..., :gen3),
+        "Periodic",
+    ]
+)
+gen3 = build_with_tags(
+    general_system(rand(4)..., :gen3),
     [
         "1D",
         "Advection",
@@ -88,8 +113,9 @@ gen3 = build_with_tags(general_system(rand(4)..., :gen3),
         "3rd Order",
         "4th Order",
         "Linear",
-        "Periodic"
-    ])
+        "Periodic",
+    ]
+)
 
 # Add to lists
 

--- a/lib/linear_convection.jl
+++ b/lib/linear_convection.jl
@@ -21,11 +21,15 @@ function linear_convection(f, ps, name = :linear_convection)
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ -v * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ f(x),
-        u(t, 0) ~ u(t, 1)]
+    bcs = [
+        u(0, x) ~ f(x),
+        u(t, 0) ~ u(t, 1),
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 10.0),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 10.0),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # Analytic solution
     u_exact = [u(t, x) ~ f(x - v * t)]
@@ -33,10 +37,12 @@ function linear_convection(f, ps, name = :linear_convection)
     tags = ["1D", "Periodic", "Linear", "Advection"]
 
     # PDE system
-    lin_conv = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
-        analytic = u_exact, metadata = tags, name = name)
+    lin_conv = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
+        analytic = u_exact, metadata = tags, name = name
+    )
 
-    lin_conv
+    return lin_conv
 end
 
 # sinusoidal input
@@ -92,11 +98,15 @@ function linear_convection_dirichlet1(f, ps, name = :linear_convection)
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ -v * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ f(x),
-        u(t, 0) ~ 0.0]
+    bcs = [
+        u(0, x) ~ f(x),
+        u(t, 0) ~ 0.0,
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 2 / ps[1]),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 2 / ps[1]),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # Analytic solution
     u_exact = [u(t, x) ~ windowlower(f(x - v * t), x - v * t)]
@@ -104,14 +114,16 @@ function linear_convection_dirichlet1(f, ps, name = :linear_convection)
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
     # PDE system
-    lin_conv = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
-        analytic = u_exact, metadata = tags, name = name)
+    lin_conv = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
+        analytic = u_exact, metadata = tags, name = name
+    )
 
-    lin_conv
+    return lin_conv
 end
 
 function windowlower(f, x, domain = (0.0, 1.0))
-    IfElse.ifelse(x <= domain[1], IfElse.ifelse(x > domain[2], f, 0.0), 0.0)
+    return IfElse.ifelse(x <= domain[1], IfElse.ifelse(x > domain[2], f, 0.0), 0.0)
 end
 
 # sinusoidal input
@@ -166,11 +178,15 @@ function linear_convection_dirichlet2(f, ps, name = :linear_convection)
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ v * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ f(x),
-        u(t, 2 / ps[1]) ~ 0.0]
+    bcs = [
+        u(0, x) ~ f(x),
+        u(t, 2 / ps[1]) ~ 0.0,
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 2 / ps[1]),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 2 / ps[1]),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # Analytic solution
     u_exact = [u(t, x) ~ windowlower(f(x - v * t), x - v * t)]
@@ -178,14 +194,16 @@ function linear_convection_dirichlet2(f, ps, name = :linear_convection)
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
     # PDE system
-    lin_conv = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
-        analytic = u_exact, metadata = tags, name = name)
+    lin_conv = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
+        analytic = u_exact, metadata = tags, name = name
+    )
 
-    lin_conv
+    return lin_conv
 end
 
 function windowupper(f, x, domain = (0.0, 1.0))
-    IfElse.ifelse(x < domain[1], IfElse.ifelse(x >= domain[2], f, 0.0), 0.0)
+    return IfElse.ifelse(x < domain[1], IfElse.ifelse(x >= domain[2], f, 0.0), 0.0)
 end
 
 # sinusoidal input
@@ -203,8 +221,10 @@ push!(convcos.metadata, "Sinusoidal")
 push!(all_systems, convcos)
 
 # triangular input
-convtri = linear_convection_dirichlet1(x -> 1.0 - abs(x - floor(x + 0.5)), [0.1],
-    :ddconvtri)
+convtri = linear_convection_dirichlet1(
+    x -> 1.0 - abs(x - floor(x + 0.5)), [0.1],
+    :ddconvtri
+)
 push!(convtri.metadata, "Triangular")
 push!(all_systems, convtri)
 
@@ -241,11 +261,15 @@ function linear_convection_dirichlet3(f, h, ps, name = :linear_convection)
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ -v * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ f(x),
-        u(t, 0.0) ~ h(t)]
+    bcs = [
+        u(0, x) ~ f(x),
+        u(t, 0.0) ~ h(t),
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 10.0),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 10.0),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # Analytic solution
     u_exact = [u(t, x) ~ IfElse.ifelse(x > v * t, f(x - v * t), h(t - x / v))]
@@ -253,10 +277,12 @@ function linear_convection_dirichlet3(f, h, ps, name = :linear_convection)
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
     # PDE system
-    lin_conv = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
-        analytic = u_exact, metadata = tags, name = name)
+    lin_conv = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
+        analytic = u_exact, metadata = tags, name = name
+    )
 
-    lin_conv
+    return lin_conv
 end
 
 funcs = [x -> x, x -> x^2, x -> x^3, sinpi, cospi, x -> 1.0 - abs(x - floor(x + 0.5)), sq]
@@ -273,12 +299,15 @@ function add_systems!(all_systems, funcs, sysconstructor, name)
             conv = sysconstructor(x -> -10 * f(x), h, [rand()], Symbol(name, i))
             push!(all_systems, conv)
             i += 1
-            conv = sysconstructor(x -> -6 * f(x), x -> -5 * h(x), [rand()],
-                Symbol(name, i))
+            conv = sysconstructor(
+                x -> -6 * f(x), x -> -5 * h(x), [rand()],
+                Symbol(name, i)
+            )
             push!(all_systems, conv)
             i += 1
         end
     end
+    return
 end
 
 add_systems!(all_systems, funcs, linear_convection_dirichlet3, "funcconv")
@@ -308,11 +337,15 @@ function linear_convection_dirichlet4(f, h, ps, name = :linear_convection)
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ v * Dx(u(t, x))
 
-    bcs = [u(0, x) ~ f(x),
-        u(t, 1.0) ~ h(t)]
+    bcs = [
+        u(0, x) ~ f(x),
+        u(t, 1.0) ~ h(t),
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 10.0),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 10.0),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # Analytic solution
     u_exact = [u(t, x) ~ IfElse.ifelse(x < v * t, f(x + v * t), h(t + x / v))]
@@ -320,10 +353,12 @@ function linear_convection_dirichlet4(f, h, ps, name = :linear_convection)
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
     # PDE system
-    lin_conv = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
-        analytic = u_exact, metadata = tags, name = name)
+    lin_conv = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [v => ps[1]],
+        analytic = u_exact, metadata = tags, name = name
+    )
 
-    lin_conv
+    return lin_conv
 end
 
 add_systems!(all_systems, funcs, linear_convection_dirichlet4, "funcconvneg")
@@ -357,11 +392,15 @@ function convection_diffusion(L, ps, name = :convection_diffusion)
 
     f_0(z) = IfElse.ifelse(z == L, 1.0, 0.0)
 
-    bcs = [f(0, z) ~ f_0(z),
-        f(t, 0) ~ 0.0, f(t, L) ~ 1.0]
+    bcs = [
+        f(0, z) ~ f_0(z),
+        f(t, 0) ~ 0.0, f(t, L) ~ 1.0,
+    ]
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 30.0),
-        z ∈ Interval(0.0, L)]
+    domains = [
+        t ∈ Interval(0.0, 30.0),
+        z ∈ Interval(0.0, L),
+    ]
 
     # Analytic/reference solution
     λ(n) = (n * π / L)^2
@@ -371,7 +410,7 @@ function convection_diffusion(L, ps, name = :convection_diffusion)
     function A(ps, t, z)
         k = ps[1]
         v = ps[2]
-        exp(-((t * v^2) / (4k) + (v * z) / (2k)))
+        return exp(-((t * v^2) / (4k) + (v * z) / (2k)))
     end
 
     function u(ps, t, z)
@@ -379,15 +418,17 @@ function convection_diffusion(L, ps, name = :convection_diffusion)
         v = ps[2]
         a = z / L * exp((t * v^2) / (4k) + (v * L) / (2k))
         s = mapreduce((+), 1:maxiters) do n
-            acu = (2 * (-1)^n * v^2 * exp(-k * λ(n) * t + (v * L) / (2k)) *
-                   (exp(k * λ(n) * t + (t * v^2) / (4k)) - 1)) /
-                  (n * π * (4 * k^2 * λ(n) + v^2))
+            acu = (
+                2 * (-1)^n * v^2 * exp(-k * λ(n) * t + (v * L) / (2k)) *
+                    (exp(k * λ(n) * t + (t * v^2) / (4k)) - 1)
+            ) /
+                (n * π * (4 * k^2 * λ(n) + v^2))
             acu += 2 / L * ((-1)^n) * exp(v * L / (2k)) * exp(-k * λ(n) * t) / sqrt(λ(n))
             acu *= sin(λ(n) * z)
 
             acu
         end
-        a + s
+        return a + s
     end
 
     ref = [f(t, z) => (ps, t, z) -> A(ps, t, z) * u(ps, t, z)]
@@ -395,11 +436,13 @@ function convection_diffusion(L, ps, name = :convection_diffusion)
     tags = ["1D", "Dirichlet", "Linear", "Advection", "Diffusion", "Monotonic"]
 
     # PDE system
-    convdiff = PDESystem(eq, bcs, domains, [t, z], [f(t, z)],
+    convdiff = PDESystem(
+        eq, bcs, domains, [t, z], [f(t, z)],
         [k => ps[1], v => ps[2]], analytic_func = ref, metadata = tags,
-        name = name)
+        name = name
+    )
 
-    convdiff
+    return convdiff
 end
 
 # L = 1.0, k = 0.01, v = 1.0
@@ -442,14 +485,18 @@ function trans_sin()
 
     u_exact(t, z) = sin(z - 2t) + 0.5 * cos(z - 2t) - 0.5 * cos(z)
 
-    bcs = [u(0, z) ~ u_exact(0, z),
+    bcs = [
+        u(0, z) ~ u_exact(0, z),
         u(t, 0) ~ u_exact(t, 0),
-        (t, 2π) ~ u_exact(t, 2π)]
+        (t, 2π) ~ u_exact(t, 2π),
+    ]
 
     # Space and time domains
 
-    domains = [t ∈ Interval(0.0, 1.0),
-        z ∈ Interval(0.0, 2π)]
+    domains = [
+        t ∈ Interval(0.0, 1.0),
+        z ∈ Interval(0.0, 2π),
+    ]
 
     # Analytic/reference solution
     ref = [u(t, z) ~ u_exact(t, z)]
@@ -458,8 +505,10 @@ function trans_sin()
 
     # PDESystem
 
-    @named trans_sin = PDESystem(eqs, bcs, domains, [t, z], [u(t, z)], analytic = ref,
-        metadata = tags)
+    @named trans_sin = PDESystem(
+        eqs, bcs, domains, [t, z], [u(t, z)], analytic = ref,
+        metadata = tags
+    )
 
-    trans_sin
+    return trans_sin
 end

--- a/lib/linear_diffusion.jl
+++ b/lib/linear_diffusion.jl
@@ -19,20 +19,26 @@ function heat_1d1()
     Dt = Differential(t)
 
     eqs = [Dt(u(t, x)) ~ D * Dxx(u(t, x))]
-    bcs = [u(0, x) ~ sin(2pi * x),
-        u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    bcs = [
+        u(0, x) ~ sin(2pi * x),
+        u(t, 0) ~ 0.0, u(t, 1) ~ 0.0,
+    ]
 
-    domains = [t ∈ Interval(0.0, 1.0),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 1.0),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     analytic = [u(t, x) ~ exp(-4pi^2 * D * t) * sin(2pi * x)]
 
     tags = ["1D", "Dirichlet", "Linear", "Diffusion", "Heat"]
 
-    @named heat_1d1 = PDESystem(eqs, bcs, domains, [t, x], [u(t, x)], [D => 1.0],
-        analytic = analytic, metadata = tags)
+    @named heat_1d1 = PDESystem(
+        eqs, bcs, domains, [t, x], [u(t, x)], [D => 1.0],
+        analytic = analytic, metadata = tags
+    )
 
-    heat_1d1
+    return heat_1d1
 end
 push!(all_systems, heat_1d1())
 
@@ -61,19 +67,25 @@ function heat_1d_neumann()
 
     # 1D PDE and boundary conditions
     eq = Dt(u(t, x)) ~ Dxx(u(t, x))
-    bcs = [u(0, x) ~ cos(x),
+    bcs = [
+        u(0, x) ~ cos(x),
         Dx(u(t, 0)) ~ 0,
-        Dx(u(t, Float64(pi))) ~ 0]
+        Dx(u(t, Float64(pi))) ~ 0,
+    ]
 
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 1.0),
-        x ∈ Interval(0.0, Float64(pi))]
+    domains = [
+        t ∈ Interval(0.0, 1.0),
+        x ∈ Interval(0.0, Float64(pi)),
+    ]
 
     analytic = [u(t, x) ~ exp(-t) * cos(x)]
 
     tags = ["1D", "Neumann", "Linear", "Diffusion", "Heat"]
     # PDE system
-    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], analytic = analytic,
-        metadata = tags)
+    return @named pdesys = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], analytic = analytic,
+        metadata = tags
+    )
 end
 push!(all_systems, heat_1d_neumann())

--- a/lib/nonlinear_diffusion.jl
+++ b/lib/nonlinear_diffusion.jl
@@ -19,23 +19,29 @@ function spherical_laplacian()
     # 1D PDE and boundary conditions
 
     eq = Dt(u(t, r)) ~ 4 / r^2 * Dr(r^2 * Dr(u(t, r)))
-    bcs = [u(0, r) ~ sin(r) / r,
+    bcs = [
+        u(0, r) ~ sin(r) / r,
         Dr(u(t, 0)) ~ 0,
-        u(t, 1) ~ exp(-4t) * sin(1)]
+        u(t, 1) ~ exp(-4t) * sin(1),
+    ]
 
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 1.0),
-        r ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 1.0),
+        r ∈ Interval(0.0, 1.0),
+    ]
 
     u_exact = [u(t, r) ~ exp.(-4t) * sin.(r) ./ r]
 
     tags = ["1D", "Dirichlet", "Neumann", "Spherical", "Diffusion"]
 
     # PDE system
-    @named sph = PDESystem(eq, bcs, domains, [t, r], [u(t, r)], analytic = u_exact,
-        metadata = tags)
+    @named sph = PDESystem(
+        eq, bcs, domains, [t, r], [u(t, r)], analytic = u_exact,
+        metadata = tags
+    )
 
-    sph
+    return sph
 end
 
 push!(all_systems, spherical_laplacian())

--- a/src/PDESystemLibrary.jl
+++ b/src/PDESystemLibrary.jl
@@ -22,7 +22,7 @@ include("../lib/general_linear_system.jl")
 include("../lib/brusselator.jl")
 
 function get_pdesys_with_tags(withtags; without = [], f = all)
-    filter(all_systems) do ex
+    return filter(all_systems) do ex
         b = f(t -> t ∈ ex.metadata, withtags)
         b && all(t -> t ∉ ex.metadata, without)
     end

--- a/test/mol_test.jl
+++ b/test/mol_test.jl
@@ -12,7 +12,7 @@ for ex in PSL.all_systems
         dxs = map(ivs) do x
             xdomain = ex.domain[findfirst(d -> isequal(x, d.variables), ex.domain)]
             x => (supremum(xdomain.domain) - infimum(xdomain.domain)) /
-                 (floor(N^(1 / length(ivs))) - 1)
+                (floor(N^(1 / length(ivs))) - 1)
         end
         if length(ivs) == 0
             continue


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)