### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDESystemLibrary"
 uuid = "d14f9848-fe58-4297-bd22-c1aba6f3000d"
 authors = ["Alex Jones (xtalax) <alex.jones@xisoft.co.uk> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
@@ -20,7 +20,7 @@ Interpolations = "0.14, 0.15, 0.16"
 Markdown = "1"
 ModelingToolkit = "9, 10, 11"
 OrdinaryDiffEq = "6"
-SciMLBase = "2"
+SciMLBase = "2, 3.1"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

Extend `SciMLBase` compat to include v3.1 (keep the existing lower bound and v2 support). No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, single-int non-scalar timeseries `sol[i]` indexing, or removed getproperty aliases like `.destats` / `.minimizer`).

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI on this PR to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns for code-side changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)