### PR TITLE
fix: use Base ifelse for symbolic conditions (un-break precompile)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.2"
 
 [deps]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -15,14 +14,13 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-DomainSets = "0.5, 0.6, 0.7"
-IfElse = "0.1"
+DomainSets = "0.6, 0.7"
 Interpolations = "0.14, 0.15, 0.16"
 Markdown = "1"
 ModelingToolkit = "9, 10, 11"
 OrdinaryDiffEq = "6, 7"
-OrdinaryDiffEqSDIRK = "1, 2"
-SciMLBase = "2, 3.1"
+OrdinaryDiffEqSDIRK = "1.2.0, 2"
+SciMLBase = "2.69.0, 3.1"
 julia = "1.10"
 
 [extras]

--- a/lib/linear_convection.jl
+++ b/lib/linear_convection.jl
@@ -61,7 +61,7 @@ push!(convtri.metadata, "Triangular")
 push!(all_systems, convtri)
 
 # square wave
-f = (x) -> IfElse.ifelse(x - floor(x) < 0.5, 1.0, -1.0)
+f = (x) -> ifelse(x - floor(x) < 0.5, 1.0, -1.0)
 
 convsquare = linear_convection(f, [-1.1], :convsquare)
 push!(convsquare.metadata, "Square")
@@ -123,7 +123,7 @@ function linear_convection_dirichlet1(f, ps, name = :linear_convection)
 end
 
 function windowlower(f, x, domain = (0.0, 1.0))
-    return IfElse.ifelse(x <= domain[1], IfElse.ifelse(x > domain[2], f, 0.0), 0.0)
+    return ifelse(x <= domain[1], ifelse(x > domain[2], f, 0.0), 0.0)
 end
 
 # sinusoidal input
@@ -146,7 +146,7 @@ push!(convtri.metadata, "Triangular")
 push!(all_systems, convtri)
 
 # square wave
-f = (x) -> IfElse.ifelse(x - floor(x) < 0.5, 1.0, -1.0)
+f = (x) -> ifelse(x - floor(x) < 0.5, 1.0, -1.0)
 
 convsquare = linear_convection_dirichlet1(f, [1.1], :dconvsquare)
 push!(convsquare.metadata, "Square")
@@ -203,7 +203,7 @@ function linear_convection_dirichlet2(f, ps, name = :linear_convection)
 end
 
 function windowupper(f, x, domain = (0.0, 1.0))
-    return IfElse.ifelse(x < domain[1], IfElse.ifelse(x >= domain[2], f, 0.0), 0.0)
+    return ifelse(x < domain[1], ifelse(x >= domain[2], f, 0.0), 0.0)
 end
 
 # sinusoidal input
@@ -229,7 +229,7 @@ push!(convtri.metadata, "Triangular")
 push!(all_systems, convtri)
 
 # square wave
-sq = f = (x) -> IfElse.ifelse(x - floor(x) < 0.5, 1.0, -1.0)
+sq = f = (x) -> ifelse(x - floor(x) < 0.5, 1.0, -1.0)
 
 convsquare = linear_convection_dirichlet1(f, [3.1], :ddconvsquare)
 push!(convsquare.metadata, "Square")
@@ -272,7 +272,7 @@ function linear_convection_dirichlet3(f, h, ps, name = :linear_convection)
     ]
 
     # Analytic solution
-    u_exact = [u(t, x) ~ IfElse.ifelse(x > v * t, f(x - v * t), h(t - x / v))]
+    u_exact = [u(t, x) ~ ifelse(x > v * t, f(x - v * t), h(t - x / v))]
 
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
@@ -348,7 +348,7 @@ function linear_convection_dirichlet4(f, h, ps, name = :linear_convection)
     ]
 
     # Analytic solution
-    u_exact = [u(t, x) ~ IfElse.ifelse(x < v * t, f(x + v * t), h(t + x / v))]
+    u_exact = [u(t, x) ~ ifelse(x < v * t, f(x + v * t), h(t + x / v))]
 
     tags = ["1D", "Dirichlet", "Linear", "Advection"]
 
@@ -390,7 +390,7 @@ function convection_diffusion(L, ps, name = :convection_diffusion)
     # 1D PDE and boundary conditions
     eq = Dt(f(t, z)) ~ k * Dzz(f(t, z)) + v * Dz(f(t, z))
 
-    f_0(z) = IfElse.ifelse(z == L, 1.0, 0.0)
+    f_0(z) = ifelse(z == L, 1.0, 0.0)
 
     bcs = [
         f(0, z) ~ f_0(z),

--- a/src/PDESystemLibrary.jl
+++ b/src/PDESystemLibrary.jl
@@ -6,8 +6,6 @@ using Interpolations
 
 import SciMLBase
 
-using IfElse
-using IfElse: ifelse
 using Markdown
 using Random
 


### PR DESCRIPTION
PDESystemLibrary currently **fails to precompile** on the modern stack (master MOL tests red): `lib/linear_convection.jl` calls `IfElse.ifelse(::Symbolics.Num,…)`, but Symbolics ≥6.29.2 dropped the `IfElse.ifelse(::Num)` overload and now overloads `Base.ifelse` → boolean-context error. This replaces all 8 `IfElse.ifelse` sites with plain `ifelse` (Base, which Symbolics overloads for `Num`), drops the unused `IfElse` dep, and raises a few resolve/precompile floors (DomainSets 0.6, OrdinaryDiffEqSDIRK 1.2.0, SciMLBase 2.69.0 — 2.68.x has a broken `LinearAliasSpecifier` constructor).

Verified on Julia 1.10: precompiles + loads, and all 195+ `ifelse`-exercising example discretizations pass.

**Downgrade CI intentionally left disabled here** — a separate `advdiff3` numerical instability under OrdinaryDiffEq v7.0.0 (unrelated to `ifelse`; FBDF "dt forced below epsilon") must be resolved first. Filed separately.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)