### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized **caller** workflows so this repo matches the org-wide standard set. Only new files under `.github/workflows/` are added; no existing workflows, `Project.toml`, or source code is touched.

**Workflows added:**
- `RunicSuggestions.yml` — Runic auto-format suggestions on PRs (this repo's format check uses `runic.yml@v1`, so Runic-based suggestions apply).
- `DependabotAutoMerge.yml` — auto-merge Dependabot PRs.

**Not added (already present / not applicable):**
- Docs preview cleanup: skipped (no `docs/` directory in this repo).

---

⚠️ **Ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
