### PR TITLE
ci: re-enable Downgrade job (runs strict, intentionally RED)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 jobs:
   downgrade:
-    if: false
+    # Runs strict (allow_reresolve defaults to false); expected RED until the advdiff3 test is fixed.
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:


### PR DESCRIPTION
Re-enables the Downgrade workflow by removing the `if: false` guard so the job actually runs.

Downgrade is re-enabled **strict** (no `allow-reresolve`; `allow_reresolve` defaults to `false`), julia "1.10", floors unchanged. The job is intentionally **RED** right now: this is a natural, visible failure (not a skipped/disabled job) pending the **advdiff3 test**. It will auto-green once that test is resolved.

Please ignore until reviewed by @ChrisRackauckas.