### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -16,6 +16,5 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical SciML CI cleanup (static edits only; not test-run):

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot@v1` workflow (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (`secrets: inherit`). Not a monorepo, so single-package form only.
- **Downgrade.yml**: removed `skip: "Pkg,TOML"` — both are Julia stdlibs and are now auto-populated by the centralized `downgrade.yml@v1` (stdlibs ∪ in-repo sublibs ∪ caller pkg). Set `julia-version: "lts"` for the downgrade floor (no `[compat] julia` floors were touched).
- **.typos.toml**: unchanged (already present at repo root).

Ignore until reviewed by @ChrisRackauckas.