### PR TITLE
Bump PDESystemLibrary to v0.1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDESystemLibrary"
 uuid = "d14f9848-fe58-4297-bd22-c1aba6f3000d"
 authors = ["Alex Jones (xtalax) <alex.jones@xisoft.co.uk> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"


### PR DESCRIPTION
Bumps `PDESystemLibrary` **v0.1.5 → v0.1.6** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Add rendered public API docs QA (#67) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)