### PR TITLE
Migrate PDESystemLibrary to strict SciMLTesting 2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,45 +4,47 @@ authors = ["Alex Jones (xtalax) <alex.jones@xisoft.co.uk> and contributors"]
 version = "0.1.6"
 
 [deps]
-DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-FunctionMaps = "a85aefff-f8ca-4649-a888-c8e5398bc76c"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
+CommonSolve = "0.2"
 DomainSets = "0.7.17, 0.8"
-FunctionMaps = "0.1"
 Interpolations = "0.14, 0.15, 0.16"
+IntervalSets = "0.7"
 Lux = "1"
-Markdown = "1"
 MethodOfLines = "0.11.14, 0.12"
 ModelingToolkit = "11.30.1"
+ModelingToolkitBase = "1"
 NonlinearSolve = "4.12"
 OptimizationOptimJL = "0.3, 0.4"
 OrdinaryDiffEq = "6.80.0, 7"
 OrdinaryDiffEqCore = "4.4"
 OrdinaryDiffEqSDIRK = "1.7, 2"
-Random = "1"
 SafeTestsets = "0.1"
 SciMLBase = "2.69.0, 3.1"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
+Symbolics = "7"
 Test = "1"
 julia = "1.10"
 
 [extras]
+DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 MethodOfLines = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MethodOfLines", "Lux", "NonlinearSolve", "OptimizationOptimJL", "OrdinaryDiffEqCore", "SafeTestsets", "SciMLTesting"]
+test = ["Test", "DomainSets", "MethodOfLines", "Lux", "ModelingToolkit", "NonlinearSolve", "OptimizationOptimJL", "OrdinaryDiffEq", "OrdinaryDiffEqCore", "SafeTestsets", "SciMLTesting"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using PDESystemLibrary
 makedocs(;
     modules = [PDESystemLibrary],
     checkdocs = :exports,
+    doctest = true,
     sitename = "PDESystemLibrary.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",

--- a/lib/general_linear_system.jl
+++ b/lib/general_linear_system.jl
@@ -81,7 +81,7 @@ advdiffno3 = build_with_tags(
 )
 
 gen1 = build_with_tags(
-    general_system(rand(4)..., :gen1),
+    general_system(0.1, 0.2, 0.3, 0.4, :gen1),
     [
         "1D",
         "Advection",
@@ -93,7 +93,7 @@ gen1 = build_with_tags(
     ]
 )
 gen2 = build_with_tags(
-    general_system(rand(4)..., :gen2),
+    general_system(0.5, 0.6, 0.7, 0.8, :gen2),
     [
         "1D",
         "Advection",
@@ -105,7 +105,7 @@ gen2 = build_with_tags(
     ]
 )
 gen3 = build_with_tags(
-    general_system(rand(4)..., :gen3),
+    general_system(0.9, 0.15, 0.25, 0.35, :gen3),
     [
         "1D",
         "Advection",

--- a/src/PDESystemLibrary.jl
+++ b/src/PDESystemLibrary.jl
@@ -1,15 +1,11 @@
 module PDESystemLibrary
-using ModelingToolkit, DomainSets, FunctionMaps
-using OrdinaryDiffEq
-using OrdinaryDiffEqSDIRK
-using Interpolations
-
-import SciMLBase
-
-using Markdown
-using Random
-
-Random.seed!(100)
+using CommonSolve: solve
+using Interpolations: Gridded, Linear, Periodic, extrapolate, interpolate
+using IntervalSets: (..), Interval
+using ModelingToolkitBase: @named, @parameters, PDESystem
+using OrdinaryDiffEqSDIRK: TRBDF2
+using SciMLBase: ODEProblem
+using Symbolics: @variables, Differential
 
 all_systems = []
 
@@ -23,11 +19,17 @@ include("../lib/brusselator.jl")
 """
     get_pdesys_with_tags(withtags; without = [], f = all)
 
-Return the PDE systems whose `metadata` tags match `withtags`.
+Return PDE systems whose `metadata` tags match `withtags`.
 
-`withtags` is an iterable of tags to include. By default all requested tags must be
-present. Pass `f = any` to select systems that contain at least one requested tag.
-Use `without` to exclude systems containing any of those tags.
+## Arguments
+
+- `withtags`: An iterable of tags to include in the result.
+
+## Keywords
+
+- `without = []`: Tags that exclude a system from the result.
+- `f = all`: Predicate that combines matches for `withtags`. Use `any` to select
+  systems matching at least one requested tag.
 
 # Examples
 

--- a/test/mol_test.jl
+++ b/test/mol_test.jl
@@ -1,23 +1,16 @@
 using PDESystemLibrary
 PSL = PDESystemLibrary
 
-using ModelingToolkit, MethodOfLines, DomainSets, OrdinaryDiffEq, NonlinearSolve, Test
+using ModelingToolkit, MethodOfLines, DomainSets, OrdinaryDiffEq, OrdinaryDiffEqSDIRK,
+    NonlinearSolve, Test
 using DomainSets: supremum, infimum
 
 N = 100
 
-# Examples that are known to be numerically unstable with the default FBDF
-# solver and central-difference spatial discretization. These are typically
-# pure-dispersive equations (e.g. `Dt(u) = Dxxx(u)`) where the spatial
-# discretization yields a near-imaginary spectrum that BDF methods handle
-# poorly. These are tracked as broken so the test suite remains green; fixing
-# them requires either an upwind/finite-volume discretization or an explicit
-# solver such as `Vern9()`.
-#
-const BROKEN_EXAMPLES = Set([:adv3])
-# `:advdiff3` has diffusion, but the third-order term still makes the default
-# FBDF solve hit `dt < eps`; Rodas5P keeps this example covered.
-const EXAMPLE_ALGORITHMS = Dict(:advdiff3 => Rodas5P())
+# `:adv3` is pure dispersive, so its central-difference discretization has a
+# near-imaginary spectrum that needs TRBDF2's implicit stability.
+# `:advdiff3` needs a Rosenbrock method for the same reason despite its diffusion.
+const EXAMPLE_ALGORITHMS = Dict(:adv3 => TRBDF2(), :advdiff3 => Rodas5P())
 
 for ex in PSL.all_systems
     @testset "Example: $(ex.name)" begin
@@ -32,34 +25,14 @@ for ex in PSL.all_systems
         elseif length(ivs) == length(ex.ivs)
             disc = MOLFiniteDifference(dxs)
             prob = discretize(ex, disc)
-            if ex.name in BROKEN_EXAMPLES
-                # solve itself may throw on numerically-unstable examples;
-                # wrap in try/catch so @test_broken sees a `false` instead of
-                # an Error when that happens.
-                @test_broken try
-                    NonlinearSolve.solve(prob, NewtonRaphson()).retcode ==
-                        SciMLBase.ReturnCode.Success
-                catch
-                    false
-                end
-            else
-                sol = NonlinearSolve.solve(prob, NewtonRaphson())
-                @test sol.retcode == SciMLBase.ReturnCode.Success
-            end
+            sol = NonlinearSolve.solve(prob, NewtonRaphson())
+            @test sol.retcode == SciMLBase.ReturnCode.Success
         else
             @parameters t
             disc = MOLFiniteDifference(dxs, t)
             prob = discretize(ex, disc)
-            if ex.name in BROKEN_EXAMPLES
-                @test_broken try
-                    solve(prob, FBDF()).retcode == SciMLBase.ReturnCode.Success
-                catch
-                    false
-                end
-            else
-                sol = solve(prob, get(EXAMPLE_ALGORITHMS, ex.name, FBDF()))
-                @test sol.retcode == SciMLBase.ReturnCode.Success
-            end
+            sol = solve(prob, get(EXAMPLE_ALGORITHMS, ex.name, FBDF()))
+            @test sol.retcode == SciMLBase.ReturnCode.Success
         end
     end
 end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,5 +8,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,32 +1,3 @@
 using PDESystemLibrary, Test
 using SciMLTesting
-using JET
-
-# JET runs in `:typo` mode (the SciMLTesting `run_qa` default). The library's
-# problem builders construct symbolic expressions from `@variables`/`@parameters`;
-# `Symbolics.wrap` has a union return type that JET widens to include the callable
-# wrapper `Symbolics.CallAndWrap` (only produced by `@variables u(..)`), so basic-mode
-# analysis emits spurious `no matching method found` union-split reports for `+/-/*/cos/sin`
-# on scalar variables that are always `Num` at runtime. Typo mode still catches real
-# undefined-name errors without these dependency-inference false positives.
-#
-# ExplicitImports findings:
-#  * no_implicit_imports: tracked-broken. The module `using`s the symbolic/solver
-#    umbrellas (ModelingToolkit, DomainSets, OrdinaryDiffEq, Interpolations) that
-#    re-export from Symbolics/ModelingToolkitBase/IntervalSets/SciMLBase/CommonSolve,
-#    so a `using X: name` rewrite would pin owner packages that reshuffle names across
-#    releases. Two entries (`limit`, `domain`) are also local definitions EI flags
-#    conservatively, so a blanket explicit-import rewrite would be wrong. Tracked in
-#    https://github.com/SciML/PDESystemLibrary.jl/issues/63 ; kept broken
-#    (auto-flags Unexpected Pass once resolved).
-#  * all_qualified_accesses_are_public: `Random.seed!` is the canonical seeding API
-#    but the Random stdlib does not declare it `public`; ignored.
-run_qa(
-    PDESystemLibrary; explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
-    jet_kwargs = (; target_modules = (PDESystemLibrary,), mode = :typo),
-    ei_kwargs = (;
-        all_qualified_accesses_are_public = (; ignore = (:seed!,)),  # Random.seed! (Random stdlib, not declared public)
-    ),
-    ei_broken = (:no_implicit_imports,)
-)
+run_qa(PDESystemLibrary)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Upgrade QA to plain strict SciMLTesting 2.4 with no exceptions or source overrides.
- Replace umbrella imports with direct public owner imports and document the public query API at its definition.
- Enable docs doctests and keep all system construction deterministic.
- Replace the masked `adv3` test with a real TRBDF2 solve; this is validated against the exact MethodOfLines problem.

## Local verification
- `julia +1.12 --project=. -e 'using Pkg; Pkg.resolve(); Pkg.instantiate(); Pkg.test()'` (`427/427` pass)\n- Strict QA `run_qa(PDESystemLibrary)` (`20/20` pass)\n- Doctested Documenter build with `checkdocs = :exports`\n- Runic check and `git diff --check`