### PR TITLE
Drop [compat] majors whose successor is 2+ years old

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 CommonSolve = "0.2"
 DomainSets = "0.7.17, 0.8"
-Interpolations = "0.14, 0.15, 0.16"
+Interpolations = "0.15, 0.16"
 IntervalSets = "0.7"
 Lux = "1"
 MethodOfLines = "0.11.14, 0.12"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop majors whose successor has been out for at least 2 years** (cutoff 2024-08-14). No code, tests, or package version were changed.

- `Project.toml` [deps] `Interpolations`: `0.14, 0.15, 0.16` → `0.15, 0.16` (drop 0.14; Interpolations 0.15.x first released 2023-11-24)

## Why

Once a newer major has been in the General registry for two years, the previous major is untested and unused. Declaring it only keeps a dead window in the resolver / downgrade graph. Remaining majors and their existing lower bounds are unchanged.

## Verification

Dates come from GitHub tags (and General registrator PRs where a tag was later rewritten). Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
