### PR TITLE
Release PDESystemLibrary 0.1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDESystemLibrary"
 uuid = "d14f9848-fe58-4297-bd22-c1aba6f3000d"
 authors = ["Alex Jones (xtalax) <alex.jones@xisoft.co.uk> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Bumps the package version from 0.1.8 to 0.1.9 so the precompiled analytic-function fix merged in https://github.com/SciML/PDESystemLibrary.jl/pull/79 can be registered. Version 0.1.8 is already registered and therefore cannot carry the merged fix to downstream benchmark environments.

## Verification

```
GROUP=Core $HOME/.juliaup/bin/julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
analytic: 1/1 passed (11m27s)
mol:      427/427 passed (18m20s)
```

```
GROUP=QA $HOME/.juliaup/bin/julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
QA: 20/20 passed (12m40.7s)
```

```
typos Project.toml
git diff --check
```

Both checks exited successfully. Runic is not applicable to this TOML-only version bump.

## Not verified

Documentation was not rebuilt because this changes only the package version and does not touch documentation or public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
