### PR TITLE
Raise Symbolics floor for downgrade MTK precompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 SciMLBase = "3.1"
 SciMLTesting = "2.4"
-Symbolics = "7"
+Symbolics = "7.37"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Please ignore this draft until reviewed by @ChrisRackauckas.

## Summary
Downgrade fails precompiling ModelingToolkitBase with the known Symbolics <7.37 / SymbolicUtils 4.46 `Base.ImmutableDict` issue. Main CI passes on latest releases.

## Changes
- `Project.toml`: Symbolics `7` -> `7.37`

Compat-only.

Made with [Cursor](https://cursor.com)