### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ RuntimeGeneratedFunctions = "0.5"
 SafeTestsets = "0.1"
 SciMLBase = "3.1"
 SciMLTesting = "2.4"
-Symbolics = "7.37"
+Symbolics = "7.39.2"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
Force Symbolics ≥7.39.2 so x86 resolves SymbolicUtils ≥4.46.4 (hasha_seed).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)